### PR TITLE
Data loader checkboxes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "moleculespath",
     "mols",
     "openchemlib",
+    "pako",
     "plotly",
     "proxyurl",
     "remotedev",

--- a/src/PoseViewerConfig.tsx
+++ b/src/PoseViewerConfig.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { unzip, zip } from 'lodash';
+
 import { Typography } from '@material-ui/core';
 
 import CardViewConfig from './components/cardView/CardViewConfig';
@@ -17,10 +19,15 @@ interface IProps {}
  */
 const PoseViewerConfig: React.FC<IProps> = () => {
   // Card View
-  const { molecules, fieldNames, fieldNickNames } = useMolecules();
+  let { molecules, fieldNames, fieldNickNames, enabledFieldNames } = useMolecules();
 
   // Scatterplot
-  // const { } = useMolecules();
+  [fieldNames = [], fieldNickNames = []] = unzip(
+    zip(fieldNames, fieldNickNames).filter(([name]) => enabledFieldNames?.includes(name!)) as [
+      string,
+      string,
+    ][],
+  );
 
   return (
     <Configuration

--- a/src/components/cardView/CardViewConfig.tsx
+++ b/src/components/cardView/CardViewConfig.tsx
@@ -21,6 +21,7 @@ import {
 } from './cardViewConfiguration';
 
 import type { DropResult } from 'react-smooth-dnd';
+
 interface IProps {
   title: string;
 }

--- a/src/components/cardView/cardViewConfiguration.ts
+++ b/src/components/cardView/cardViewConfiguration.ts
@@ -46,11 +46,13 @@ export const [
   }),
 });
 
-moleculesStore.subscribe(({ fieldNames, fieldNickNames }) => {
+moleculesStore.subscribe(({ fieldNames, fieldNickNames, enabledFieldNames }) => {
   // This check is probably unnecessary
   if (fieldNames.length === fieldNickNames.length) {
-    const zipped = zip(fieldNames, fieldNickNames) as [string, string][];
+    let zipped = zip(fieldNames, fieldNickNames) as [string, string][];
+    zipped = zipped.filter(([name]) => enabledFieldNames?.includes(name));
     setFields(zipped.map(([name, title]) => ({ name, title })));
-    setEnabledFields(fieldNames.slice(0, 5));
+
+    setEnabledFields(fieldNames.filter((name) => enabledFieldNames?.includes(name)).slice(0, 5));
   }
 });

--- a/src/components/dataLoader/DataLoader.tsx
+++ b/src/components/dataLoader/DataLoader.tsx
@@ -25,6 +25,7 @@ const getFieldsFromForm = (form: HTMLFormElement, fieldNames: string[]): FieldCo
     const isNumeric = dtype === 'int' || dtype === 'float';
 
     return {
+      enabled: form?.[`${name}-enabled`]?.checked,
       name: name,
       nickname: form?.[`${name}-nickname`]?.value,
       dtype,

--- a/src/components/dataLoader/FieldConfigInputs.tsx
+++ b/src/components/dataLoader/FieldConfigInputs.tsx
@@ -35,7 +35,6 @@ const FieldConfigInputs = ({ name, config }: IProps) => {
         name={`${name}-enabled`}
         checked={!!enabled}
         onChange={() => setEnabled(!enabled)}
-        disabled={name === 'oclSmiles'}
       />
       <Typography align="left" noWrap>
         {name}

--- a/src/components/dataLoader/FieldConfigInputs.tsx
+++ b/src/components/dataLoader/FieldConfigInputs.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import {
+  Checkbox,
   FormControl,
   InputLabel,
   MenuItem,
@@ -18,6 +19,7 @@ interface IProps {
 
 const FieldConfigInputs = ({ name, config }: IProps) => {
   const [isNumeric, setIsNumeric] = useState(config?.dtype === 'int' || config?.dtype === 'float'); // Initial value depends on the defaultValue given to select field
+  const [enabled, setEnabled] = useState(config?.enabled ?? true);
 
   const handleDtypeChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     if (event.target.value === 'text') {
@@ -29,7 +31,15 @@ const FieldConfigInputs = ({ name, config }: IProps) => {
 
   return (
     <>
-      <Typography noWrap>{name}</Typography>
+      <Checkbox
+        name={`${name}-enabled`}
+        checked={!!enabled}
+        onChange={() => setEnabled(!enabled)}
+        disabled={name === 'oclSmiles'}
+      />
+      <Typography align="left" noWrap>
+        {name}
+      </Typography>
       <TextField
         name={`${name}-nickname`}
         size="small"

--- a/src/components/dataLoader/FieldConfiguration.tsx
+++ b/src/components/dataLoader/FieldConfiguration.tsx
@@ -14,16 +14,18 @@ const FieldConfiguration = ({ currentSource, fieldNames }: IProps) => {
   const { configs, url, configName, maxRecords } = currentSource;
   return (
     <FieldSet>
-      {fieldNames.map((name, index) => {
-        const config = configs.find((field) => field.name === name);
-        return (
-          <FieldConfigInputs
-            key={`${url}-${configName}-${maxRecords}-${index}`}
-            name={name}
-            config={config}
-          />
-        );
-      })}
+      {fieldNames
+        .filter((name) => name !== 'oclSmiles')
+        .map((name, index) => {
+          const config = configs.find((field) => field.name === name);
+          return (
+            <FieldConfigInputs
+              key={`${url}-${configName}-${maxRecords}-${index}`}
+              name={name}
+              config={config}
+            />
+          );
+        })}
     </FieldSet>
   );
 };

--- a/src/components/dataLoader/FieldConfiguration.tsx
+++ b/src/components/dataLoader/FieldConfiguration.tsx
@@ -32,7 +32,8 @@ export default FieldConfiguration;
 
 const FieldSet = styled.div`
   display: grid;
+  align-items: center;
   padding: ${({ theme }) => theme.spacing(1)}px;
-  grid-template-columns: 12rem repeat(4, 8rem);
+  grid-template-columns: auto 10rem repeat(4, 8rem);
   grid-gap: ${({ theme }) => theme.spacing(1)}px;
 `;

--- a/src/components/dataLoader/sources.ts
+++ b/src/components/dataLoader/sources.ts
@@ -6,6 +6,7 @@ import { useRedux } from 'hooks-for-redux';
 
 export interface FieldConfig {
   name: string;
+  enabled: boolean;
   nickname?: string;
   rank?: 'asc' | 'desc'; // TODO: make ENUM
   dtype?: string; // TODO: make ENUM

--- a/src/components/scatterplot/Scatterplot.tsx
+++ b/src/components/scatterplot/Scatterplot.tsx
@@ -42,7 +42,7 @@ interface IProps {
 
 const ScatterPlot = ({ width }: IProps) => {
   const theme = useTheme();
-  const { molecules, fieldNames, fieldNickNames } = useMolecules();
+  let { molecules, fieldNames, fieldNickNames } = useMolecules();
 
   let { xprop, yprop, size, colour } = useScatterplotConfiguration();
 


### PR DESCRIPTION
- Adds a checkbox to each field in the dataloader to enable whether it should be parsed or not
- The oclSmiles record which we add is no longer shown here as it is needed to exist for defaults